### PR TITLE
Fix "read more" URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@ layout: default
         <h2 class="post-title" itemprop="headline"><a href="{{ post.url | prepend: site.baseurl }}">{{ post.title | xml_escape }}</a></h2>
       </header>
       <div class="post-excerpt" itemprop="description">
-        {{ post.excerpt | strip_html }}<a class="read-more" href="{{url}}">…</a>
+        {{ post.excerpt | strip_html }}<a class="read-more" href="{{ post.url | prepend: site.baseurl }}">…</a>
       </div>
       <div class="post-footer">
         <ul class="x-separated-list x-separated-list-meta x-separated-list-small">


### PR DESCRIPTION
@barepants: Thanks for making this theme available. :heart::metal:

This pull request fixes the "read more" URL that's shown after each post excerpt:

![before](https://cloud.githubusercontent.com/assets/2988/23589785/d5b034dc-01a1-11e7-946e-9c905ec9c21d.png)

![after](https://cloud.githubusercontent.com/assets/2988/23589784/d5af054e-01a1-11e7-8da0-8a3ee864ba60.png)

I hope this helps.